### PR TITLE
FreeBSD and TrueNAS import support and autoinstall templates

### DIFF
--- a/autoinstall_snippets/BSD-DNS-config
+++ b/autoinstall_snippets/BSD-DNS-config
@@ -1,0 +1,7 @@
+#if $len($name_servers) > 0
+cat >>/etc/resolv.conf <<FOE
+    #for $nameserver in $name_servers
+nameserver $nameserver
+    #end for
+FOE
+#end if

--- a/autoinstall_snippets/BSD-INTERFACES-var
+++ b/autoinstall_snippets/BSD-INTERFACES-var
@@ -1,0 +1,28 @@
+## start of cobbler network_config generated code
+#if $getVar("system_name","") != ""
+    #set ikeys = $interfaces.keys()
+    #import re
+    #for $iname in $ikeys
+        #set $idata = $interfaces[$iname]
+        ## Ignore BMC interface
+        #if $idata["interface_type"].lower() == "bmc"
+            #continue
+        #end if
+    #end for
+    #for $iname in $ikeys
+        #set $idata    = $interfaces[$iname]
+        #set $type     = $idata["interface_type"]
+        ## Ignore BMC interface
+        #if $type == "bmc"
+            #continue
+        #end if
+        #if $iname == "default":
+INTERFACES="em0"
+        #else
+INTERFACES="$iname"
+        #end if
+    #end for
+#else
+## profile based install so just provide one interface for starters
+INTERFACES="em0"
+#end if

--- a/autoinstall_snippets/network_config_BSD
+++ b/autoinstall_snippets/network_config_BSD
@@ -1,0 +1,74 @@
+## start of cobbler network_config generated code
+#if $getVar("system_name","") != ""
+    #set ikeys = $interfaces.keys()
+    #import re
+    #for $iname in $ikeys
+        #set $idata = $interfaces[$iname]
+        ## Ignore BMC interface
+        #if $idata["interface_type"].lower() == "bmc"
+            #continue
+        #end if
+    #end for
+    #for $iname in $ikeys
+        #set $idata    = $interfaces[$iname]
+        #set $mac      = $idata["mac_address"]
+        #set $static   = $idata["static"]
+        #set $ip       = $idata["ip_address"]
+        #set $netmask  = $idata["netmask"]
+        #set $type     = $idata["interface_type"]
+        ## Ignore BMC interface
+        #if $type == "bmc"
+            #continue
+        #end if
+        #if $hostname ==""
+            #set $myhostname = $getVar("system_name","").replace("_","-")
+hostname="$myhostname"
+        #else
+hostname="$hostname"
+        #end if
+        #if $mac != ""
+            #if $iname == "default":
+                #if $static == True:
+                    #if $ip != "":
+ifconfig_em0="inet $ip netmask $netmask"
+                    #else
+ifconfig_em0="DHCP"
+                        #continue
+                    #end if
+                    #if $gateway != "":
+defaultrouter="$gateway"
+netwait_enabled="YES"
+netwait_ip="$gateway"
+netwait_timeout="60"
+                    #end if
+                #else
+ifconfig_em0="DHCP"
+                #end if
+            #else
+                #if $static == True:
+                    #if $ip != "":
+ifconfig_$iname="inet $ip netmask $netmask"
+                    #else
+ifconfig_$iname="DHCP"
+                        #continue
+                    #end if
+                    #if $gateway != "":
+defaultrouter="$gateway"
+netwait_enabled="YES"
+netwait_ip="$gateway"
+netwait_timeout="60"
+                    #end if
+                #else
+ifconfig_$iname="DHCP"
+                #end if
+            #end if
+        #else
+ifconfig_em0="DHCP"
+        #end if
+    #end for
+#else
+## profile based install so just provide one interface for starters
+    #set $myhostname = $getVar('hostname',$getVar('name','cobbler')).replace("_","-")
+hostname="$myhostname"
+ifconfig_em0="DHCP"
+#end if

--- a/autoinstall_templates/installerconfig
+++ b/autoinstall_templates/installerconfig
@@ -1,0 +1,37 @@
+DISTRIBUTIONS="base.txz kernel.txz lib32.txz"
+${SNIPPET('BSD-INTERFACES-var')}export nonInteractive="YES"
+export ZFSBOOT_DISKS="ada0"
+export ZFSBOOT_VDEV_TYPE="stripe"
+export ZFSBOOT_FORCE_4K_SECTORS="1"
+export ZFSBOOT_SWAP_SIZE="2g"
+export ZFSBOOT_SWAP_MIRROR="1"
+export ZFSBOOT_POOL_CREATE_OPTIONS=""
+export ZFSBOOT_BEROOT_NAME="ROOT"
+export ZFSBOOT_BOOTFS_NAME="default"
+export ZFSBOOT_DATASETS="
+    /\$ZFSBOOT_BEROOT_NAME mountpoint=none
+    /\$ZFSBOOT_BEROOT_NAME/\$ZFSBOOT_BOOTFS_NAME mountpoint=/
+    /tmp mountpoint=/tmp,setuid=off
+    /usr mountpoint=/usr,canmount=off
+    /usr/local mountpoint=/usr/local
+    /var mountpoint=/var
+    /var/db mountpoint=/var/db,canmount=off
+    /var/db/mysql mountpoint=/var/db/mysql,recordsize=16k,atime=off,primarycache=metadata
+    /var/db/mysql/logs mountpoint=/var/db/mysql/logs,recordsize=128k,atime=off,primarycache=metadata
+    /var/db/pkg mountpoint=/var/db/pkg
+    /var/tmp mountpoint=/var/tmp,setuid=off
+    /home mountpoint=/home
+"
+
+#!/bin/sh
+cat >>/etc/rc.conf <<FOE
+zfs_enable="YES"
+sshd_enable="YES"
+${SNIPPET('network_config_BSD')}dumpdev="AUTO"
+FOE
+${SNIPPET('BSD-DNS-config')}echo '$6$5RSID4916Oa7QiGd\$GQ0qSuNe7bfftnYxfFYxaciXwhQ1Rpftokr89cQE/eM3Y0GRfoSdEn15c8B5qdSzzFJEK6xItWUiV26V9Rs7f.' | pw user mod root -H 0
+sed -i '' 's/#PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config
+whoami && echo ~
+ssh-keygen -t rsa -b 2048 -m ssh2 -f /root/.ssh/id_rsa -N ""
+fetch -o /root/.ssh/authorized_keys http://10.0.0.10/cblr/pub/Cobbler-id_rsa.pub
+reboot

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -139,6 +139,7 @@ class _ImportSignatureManager(ManagerModule):
             self.logger.info("no %s found, please install wimlib-utils", cmd)
         elif (
             ftype.mime_type == "text/plain"
+            or ftype.mime_type == "application/json"
             or ftype.mime_type == "text/x-shellscript"
         ):
             with open(filename, 'r') as f:

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -137,7 +137,10 @@ class _ImportSignatureManager(ManagerModule):
                 return utils.subprocess_get(cmd).splitlines()
 
             self.logger.info("no %s found, please install wimlib-utils", cmd)
-        elif ftype.mime_type == "text/plain":
+        elif (
+            ftype.mime_type == "text/plain"
+            or ftype.mime_type == "text/x-shellscript"
+        ):
             with open(filename, 'r') as f:
                 return f.readlines()
         else:
@@ -268,7 +271,13 @@ class _ImportSignatureManager(ManagerModule):
                                     # version file to ensure it's the right version
                                     if sigdata["breeds"][breed][version]["version_file_regex"]:
                                         vf_re = re.compile(sigdata["breeds"][breed][version]["version_file_regex"])
-                                        vf_lines = self.get_file_lines(os.path.join(root, fname))
+                                        ftype_sig = magic.detect_from_filename(os.path.join(root, fname))
+                                        if ftype_sig.mime_type == "application/gzip":
+                                            with gzip.open(os.path.join(root, x), 'r') as f:
+                                                vf_lines = f.readlines()
+                                        else:
+                                            vf_lines = self.get_file_lines(os.path.join(root, fname))
+
                                         for line in vf_lines:
                                             if vf_re.match(line):
                                                 break

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -73,8 +73,8 @@ CHEETAH_ERROR_DISCLAIMER = """
 MODULE_CACHE = {}
 SIGNATURE_CACHE = {}
 
-_re_kernel = re.compile(r'(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|mboot\.c32|.+\.kernel)')
-_re_initrd = re.compile(r'(initrd(.*)\.img|ramdisk\.image\.gz|boot\.sdi|imgpayld\.tgz)')
+_re_kernel = re.compile(r'(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|mboot\.c32|.+\.kernel|base\.txz)')
+_re_initrd = re.compile(r'(initrd(.*)\.img|ramdisk\.image\.gz|boot\.sdi|imgpayld\.tgz|base\.txz)')
 
 
 class DHCP(enum.Enum):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -73,8 +73,8 @@ CHEETAH_ERROR_DISCLAIMER = """
 MODULE_CACHE = {}
 SIGNATURE_CACHE = {}
 
-_re_kernel = re.compile(r'(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|mboot\.c32|.+\.kernel|base\.txz)')
-_re_initrd = re.compile(r'(initrd(.*)\.img|ramdisk\.image\.gz|boot\.sdi|imgpayld\.tgz|base\.txz)')
+_re_kernel = re.compile(r'(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|mboot\.c32|.+\.kernel|base-os-13.0-U6.2.*.tgz|base\.txz)')
+_re_initrd = re.compile(r'(initrd(.*)\.img|ramdisk\.image\.gz|boot\.sdi|imgpayld\.tgz|base-os-13.0-U6.2.*.tgz|base\.txz)')
 
 
 class DHCP(enum.Enum):

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -3312,6 +3312,29 @@
         }
       }
     },
+    "truenas-core": {
+      "truenas-core13.0.6.2": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "^TrueNAS-MANIFEST$",
+        "version_file_regex": "^.*TrueNAS-13.0-U6.2.*$",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base-os-13.0-U6.2.*.tgz",
+        "initrd_file": "base-os-13.0-U6.2.*.tgz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      }
+    },
     "freebsd": {
       "freebsd8.2": {
         "signatures": [

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -93,7 +93,7 @@
         "signatures": [
           "Packages"
         ],
-        "version_file": "(redhat|sl|slf|centos|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*7(Server)*[\\.-]+(.*)\\.rpm",
+        "version_file": "(redhat|sl|slf|anolis|centos|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*7(Server)*[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,
@@ -127,9 +127,10 @@
       },
       "rhel8": {
         "signatures": [
-          "BaseOS"
+          "BaseOS",
+          "Minimal"
         ],
-        "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
+        "version_file": "(redhat|sl|slf|almalinux|anolis|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,
@@ -154,9 +155,10 @@
       },
       "rhel9": {
         "signatures": [
-          "BaseOS"
+          "BaseOS",
+          "Minimal"
         ],
-        "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*9[\\.-]+(.*)\\.rpm",
+        "version_file": "(redhat|sl|slf|almalinux|anolis|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*9[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,
@@ -867,13 +869,179 @@
         "kernel_options": "repo=$tree",
         "kernel_options_post": "",
         "boot_files": [],
-        "boot_loaders": []
+        "boot_loaders": {}
+      },
+      "fedora36": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "(fedora)-release-36-(.*)\\.noarch\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "aarch64",
+          "armhfp",
+          "ppc64le",
+          "s390x",
+          "x86_64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "repo=$tree",
+        "kernel_options_post": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "fedora37": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "(fedora)-release-37-(.*)\\.noarch\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "aarch64",
+          "ppc64le",
+          "s390x",
+          "x86_64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "repo=$tree",
+        "kernel_options_post": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "fedora38": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "(fedora)-release-38-(.*)\\.noarch\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "aarch64",
+          "ppc64le",
+          "s390x",
+          "x86_64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "repo=$tree",
+        "kernel_options_post": "",
+        "boot_files": [],
+        "boot_loaders": {}
       },
       "cloudlinux6": {
         "signatures": [
           "Packages"
         ],
-        "version_file": "(cloudlinux)-release-(.*)\\.rpm",
+        "version_file": "(cloudlinux)-release-(6.*)\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*).rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "x86_64",
+          "ppc",
+          "ppc64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "cloudlinux7": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "(cloudlinux)-release-(7.*)\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*).rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "x86_64",
+          "ppc",
+          "ppc64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "cloudlinux8": {
+        "signatures": [
+          "BaseOS"
+        ],
+        "version_file": "(cloudlinux)-release-(8.*)\\.(.*)\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*).rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "x86_64",
+          "ppc",
+          "ppc64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "cloudlinux9": {
+        "signatures": [
+          "BaseOS"
+        ],
+        "version_file": "(cloudlinux)-release-(9.*)\\.(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,
@@ -1024,6 +1192,32 @@
         "supported_arches": [
           "i386",
           "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.seed",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "bookworm": {
+        "signatures": [
+          "dists"
+        ],
+        "version_file": "Release",
+        "version_file_regex": "Codename: bookworm",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "aarch64",
+          "ppc64le",
+          "s390x"
         ],
         "supported_repo_breeds": [
           "apt"
@@ -1550,6 +1744,58 @@
         "boot_files": [],
         "boot_loaders": {}
       },
+      "groovy": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: groovy|Ubuntu 20.10",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "hirsute": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: hirsute|Ubuntu 21.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
       "impish": {
         "signatures": [
           "dists",
@@ -1558,6 +1804,110 @@
         "version_file": "Release|info",
         "version_file_regex": "Suite: impish|Ubuntu-Server 21\\.10",
         "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "jammy": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: jammy|Ubuntu 22.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "kinetic": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: kinetic|Ubuntu 22.10",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "lunar": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: lunar|Ubuntu 23.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "mantic": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: mantic|Ubuntu 23.10",
+        "kernel_arch": "linux_headers-(.*)\\.deb",
         "kernel_arch_regex": null,
         "supported_arches": [
           "i386",
@@ -2414,6 +2764,30 @@
           ]
         }
       },
+      "sles15": {
+        "signatures": [
+          "suse"
+        ],
+        "version_file": "sles-release-15(.*).rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64",
+          "s390x",
+          "ppc64le"
+        ],
+        "supported_repo_breeds": [
+          "yum"
+        ],
+        "kernel_file": "linux[64.gz]?",
+        "initrd_file": "initrd[64]?",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample_autoyast.xml",
+        "kernel_options": "install=$tree",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
       "sles15generic": {
         "signatures": [
           "."
@@ -2691,7 +3065,7 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "b\\.z",
         "initrd_file": "vmkboot\\.gz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi4.ks",
@@ -2717,16 +3091,22 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "tboot\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi5.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi5.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       },
       "esxi51": {
         "signatures": [
@@ -2740,16 +3120,22 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "tboot\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi5.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi51.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       },
       "esxi55": {
         "signatures": [
@@ -2763,16 +3149,22 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "tboot\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi5.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi55.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       },
       "esxi60": {
         "signatures": [
@@ -2786,16 +3178,22 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "tboot\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi5.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi60.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       },
       "esxi65": {
         "signatures": [
@@ -2809,16 +3207,22 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "tboot\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi6.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi65.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       },
       "esxi67": {
         "signatures": [
@@ -2832,16 +3236,51 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "b\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi6.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi67.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
+      },
+      "esxi80": {
+        "signatures": [
+          "b.b00"
+        ],
+        "version_file": "vmware-esx-base-osl\\.txt",
+        "version_file_regex": "^(VMware )?ESXi( )?(v)?8(\\.)?0(\\.)?.*$",
+        "kernel_arch": "tools\\.t00",
+        "kernel_arch_regex": "^.*(x86_64).*$",
+        "supported_arches": [
+          "x86_64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "b\\.b00",
+        "initrd_file": "imgpayld\\.tgz",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample_esxi8.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [
+          "*.*"
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       },
       "esxi70": {
         "signatures": [
@@ -2855,16 +3294,22 @@
           "x86_64"
         ],
         "supported_repo_breeds": [],
-        "kernel_file": "mboot\\.c32",
+        "kernel_file": "b\\.b00",
         "initrd_file": "imgpayld\\.tgz",
         "isolinux_ok": false,
         "default_autoinstall": "sample_esxi7.ks",
         "kernel_options": "",
         "kernel_options_post": "",
-        "template_files": "/etc/cobbler/boot_loader_conf/bootcfg_esxi70.template=$local_img_path/cobbler-boot.cfg",
+        "template_files": "",
         "boot_files": [
           "*.*"
-        ]
+        ],
+        "boot_loaders": {
+          "x86_64": [
+            "pxe",
+            "ipxe"
+          ]
+        }
       }
     },
     "freebsd": {
@@ -3172,7 +3617,38 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "i386",
-          "amd64"
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64",
+          "arm"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd12.1": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"12.1-RELEASE.*\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "base.txz",
@@ -3189,6 +3665,27 @@
         ],
         "version_file": "freebsd-version",
         "version_file_regex": "USERLAND_VERSION=\"11.3-RELEASE.*\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd11.4": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"11.4-RELEASE.*\"",
         "kernel_arch": "device\\.hints",
         "kernel_arch_regex": null,
         "supported_arches": [
@@ -3239,7 +3736,8 @@
           "ppc64",
           "ppc64le",
           "ppc64el",
-          "aarch64"
+          "aarch64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "base.txz",
@@ -3264,7 +3762,34 @@
           "ppc64",
           "ppc64le",
           "ppc64el",
-          "aarch64"
+          "aarch64",
+          "arm"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd12.4": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"12.4-RELEASE\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "base.txz",
@@ -3281,6 +3806,131 @@
         ],
         "version_file": "freebsd-version",
         "version_file_regex": "USERLAND_VERSION=\"13.0-RELEASE\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd13.1": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"13.1-RELEASE\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd13.2": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"13.2-RELEASE\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd13.3": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"13.3-RELEASE\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd14.0": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"14.0-RELEASE\"",
+        "kernel_arch": "device\\.hints",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64",
+          "ppc64",
+          "ppc64le",
+          "ppc64el",
+          "aarch64"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "base.txz",
+        "initrd_file": "base.txz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "freebsd14.1": {
+        "signatures": [
+          "boot"
+        ],
+        "version_file": "freebsd-version",
+        "version_file_regex": "USERLAND_VERSION=\"14.1-RELEASE\"",
         "kernel_arch": "device\\.hints",
         "kernel_arch_regex": null,
         "supported_arches": [
@@ -3355,7 +4005,8 @@
         "kernel_arch": "xen\\.gz",
         "kernel_arch_regex": "^.*(x86_64).*$",
         "supported_arches": [
-          "x86_64"
+          "x86_64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "mboot\\.c32",
@@ -3377,7 +4028,8 @@
         "kernel_arch": "xen\\.gz",
         "kernel_arch_regex": "^.*(x86_64).*$",
         "supported_arches": [
-          "x86_64"
+          "x86_64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "mboot\\.c32",
@@ -3399,7 +4051,8 @@
         "kernel_arch": "xen\\.gz",
         "kernel_arch_regex": "^.*(x86_64).*$",
         "supported_arches": [
-          "x86_64"
+          "x86_64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "mboot\\.c32",
@@ -3421,7 +4074,8 @@
         "kernel_arch": "xen\\.gz",
         "kernel_arch_regex": "^.*(x86_64).*$",
         "supported_arches": [
-          "x86_64"
+          "x86_64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "mboot\\.c32",
@@ -3443,7 +4097,77 @@
         "kernel_arch": "xen\\.gz",
         "kernel_arch_regex": "^.*(x86_64).*$",
         "supported_arches": [
-          "x86_64"
+          "x86_64",
+          "arm"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "mboot\\.c32",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xenserver740": {
+        "signatures": [
+          "packages.xenserver"
+        ],
+        "version_file": "^XS-REPOSITORY$",
+        "version_file_regex": "^.*product=\"XenServer\" version=\"7\\.4\\.([0-9]+)\".*$",
+        "kernel_arch": "xen\\.gz",
+        "kernel_arch_regex": "^.*(x86_64).*$",
+        "supported_arches": [
+          "x86_64",
+          "arm"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "mboot\\.c32",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xenserver750": {
+        "signatures": [
+          "packages.xenserver"
+        ],
+        "version_file": "^XS-REPOSITORY$",
+        "version_file_regex": "^.*product=\"XenServer\" version=\"7\\.5\\.([0-9]+)\".*$",
+        "kernel_arch": "xen\\.gz",
+        "kernel_arch_regex": "^.*(x86_64).*$",
+        "supported_arches": [
+          "x86_64",
+          "arm"
+        ],
+        "supported_repo_breeds": [],
+        "kernel_file": "mboot\\.c32",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xenserver760": {
+        "signatures": [
+          "packages.xenserver"
+        ],
+        "version_file": "^XS-REPOSITORY$",
+        "version_file_regex": "^.*product=\"XenServer\" version=\"7\\.6\\.([0-9]+)\".*$",
+        "kernel_arch": "xen\\.gz",
+        "kernel_arch_regex": "^.*(x86_64).*$",
+        "supported_arches": [
+          "x86_64",
+          "arm"
         ],
         "supported_repo_breeds": [],
         "kernel_file": "mboot\\.c32",
@@ -3767,7 +4491,7 @@
           ]
         },
         "supported_repo_breeds": [],
-        "kernel_file": "pxeboot\\.n12",
+        "kernel_file": "wimboot",
         "initrd_file": "boot\\.sdi",
         "default_autoinstall": "win.ks",
         "kernel_options": "",


### PR DESCRIPTION
added import functionality as well as autoinstall template, snippet and script for FreeBSD and TrueNAS 13.0 - 14.1. Requires NFS server not managed by Cobbler.